### PR TITLE
Fix compilation issues with recent mruby.

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -13,6 +13,7 @@ MRuby::Gem::Specification.new('mruby-zmq') do |spec|
   spec.add_dependency 'mruby-time'
   spec.add_dependency 'mruby-sprintf'
   spec.add_dependency 'mruby-class-ext'
+  spec.add_dependency 'mruby-metaprog'
   spec.add_test_dependency 'mruby-sleep'
 
   task :clean do

--- a/src/mrb_libzmq.c
+++ b/src/mrb_libzmq.c
@@ -625,7 +625,7 @@ mrb_zmq_z85_encode(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_ARGUMENT_ERROR, "data size must be divisible by 4");
   }
 
-  mrb_value dest = mrb_str_new(mrb, NULL, mrb_fixnum(mrb_flo_to_fixnum(mrb, mrb_fixnum_mul(mrb, mrb_fixnum_value(size), mrb_float_value(mrb, 1.25)))));
+  mrb_value dest = mrb_str_new(mrb, NULL, mrb_fixnum(mrb_flo_to_fixnum(mrb, mrb_num_mul(mrb, mrb_fixnum_value(size), mrb_float_value(mrb, 1.25)))));
 
   char *rc = zmq_z85_encode(RSTRING_PTR(dest), (uint8_t *) data, size);
   if (unlikely(!rc)) {

--- a/src/mrb_libzmq.c
+++ b/src/mrb_libzmq.c
@@ -1284,7 +1284,7 @@ mrb_mruby_zmq_gem_init(mrb_state* mrb)
   zmq_mod = mrb_define_module(mrb, "ZMQ");
   zmq_msg_class = mrb_define_class_under(mrb, zmq_mod, "Msg", mrb->object_class);
   MRB_SET_INSTANCE_TT(zmq_msg_class, MRB_TT_DATA);
-  mrb_define_method(mrb, zmq_msg_class, "initialize", mrb_zmq_msg_new, MRB_ARGS_NONE());
+  mrb_define_method(mrb, zmq_msg_class, "initialize", mrb_zmq_msg_new, MRB_ARGS_OPT(1));
   mrb_define_method(mrb, zmq_msg_class, "initialize_copy", mrb_zmq_msg_copy, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, zmq_msg_class, "to_str", mrb_zmq_msg_to_str, MRB_ARGS_NONE());
   mrb_define_method(mrb, zmq_msg_class, "==", mrb_zmq_msg_eql, MRB_ARGS_REQ(1));

--- a/test/zmq.rb
+++ b/test/zmq.rb
@@ -77,3 +77,9 @@ end
 #     assert_equal("test_zmq", msg.group)
 #   end
 # end
+
+assert('Msg') do
+  # Ensures optional parameter works.
+  ZMQ::Msg.new()
+  ZMQ::Msg.new("hallo")
+end


### PR DESCRIPTION
Each commit message describes the problem they solve.

Don't hesitate to ask if you have questions.

* * *

I can break-out badf10fed37ac69e5522a01c512188fb61268d75 if desired, as it strictly wasn't needed to fix compilation with recent mruby versions. Though I'm not positive as to if it is a change in mruby's handling of optional arguments or an oversight in the original implementation. Furthermore I have not verified if other functions could face the same issue.

* * *

With the CI failure, I see things might not be exactly right.

I see that the CI tests against *whatever mruby master is*.

I tested against 2.1.1.

I will take a look later to see what's up with the current tests.